### PR TITLE
Extend NewRecursiveMetricsFromTags by Options.

### DIFF
--- a/v0/pkg/prometheus/gen/collector.go
+++ b/v0/pkg/prometheus/gen/collector.go
@@ -1,6 +1,7 @@
 package gen
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/abergmeier/kafka_stats_exporter/internal/collector"
@@ -9,24 +10,69 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
+// RecursiveMetricsOption represents an opaque option implementation
+// for creating RecursiveMetrics
+type RecursiveMetricsOption interface {
+}
+
+// WithLabelNameTransform creates an Option for transforming Prometheus label names
+// Especially useful since Prometheus has a very limited range of characters allowed for
+// label names.
+// Does not transform passed in Labels!
+func WithLabelNameTransform(fun types.LabelNameTransformer) RecursiveMetricsOption {
+	return &recursiveMetricsLabelNameTransform{
+		fun: fun,
+	}
+}
+
+type recursiveMetricsLabelNameTransform struct {
+	fun types.LabelNameTransformer
+}
+
 // NewRecursiveMetricsFromTags builds Metrics recursively for the type of `tagged`.
 // Uses tags to build Metrics. Does not expose metrics directly.
 // Returns `Collector` for reading created Metrics and `Updater` for
 // updating the Metrics with a Type of `tagged`.
-func NewRecursiveMetricsFromTags(tagged interface{}) (prometheus.Collector, Updater) {
+func NewRecursiveMetricsFromTags(tagged interface{}, opts ...RecursiveMetricsOption) (prometheus.Collector, Updater) {
 	t := reflect.TypeOf(tagged)
 	switch t.Kind() {
 	case reflect.Pointer:
 		t = t.Elem()
 	}
 
+	transforms := []types.LabelNameTransformer{}
+	for _, opt := range opts {
+		switch trans := opt.(type) {
+		case *recursiveMetricsLabelNameTransform:
+			transforms = append(transforms, trans.fun)
+		default:
+			panic(fmt.Sprintf("Unrecognized option %#v", opt))
+		}
+	}
+
+	var transform types.LabelNameTransformer
+	switch len(transforms) {
+	case 0:
+		transform = func(value string) (labelName string) { return value }
+	case 1:
+		transform = transforms[0]
+	default:
+		transform = func(value string) (labelName string) {
+			for _, trans := range transforms {
+				value = trans(value)
+			}
+			return value
+		}
+	}
+
 	rlr := label.RecursiveReflector{}
-	fillLabels(t, &rlr, "", types.LabelNames{})
+	fillLabels(t, &rlr, "", types.LabelNames{}, transform)
 
 	cs := &collector.Collectors{}
 	cs.Fill(t, &rlr, "")
 	u := &updater{
-		c: cs,
+		c:                  cs,
+		labelNameTransform: transform,
 	}
 	return cs, u
 }

--- a/v0/pkg/prometheus/gen/labels_test.go
+++ b/v0/pkg/prometheus/gen/labels_test.go
@@ -188,7 +188,7 @@ func TestMakeLabelReflector(t *testing.T) {
 
 func TestLabelReflectorSimple(t *testing.T) {
 	rlr := label.RecursiveReflector{}
-	fillLabels(reflect.TypeOf(simpleStats{}), &rlr, "", types.LabelNames{})
+	fillLabels(reflect.TypeOf(simpleStats{}), &rlr, "", types.LabelNames{}, func(value string) (labelName string) { return value })
 	d := cmp.Diff(rlr, expectedSimpleLabelReflector, cmp.Comparer(internal.CompareType))
 	if d != "" {
 		t.Fatal("Diff", d)
@@ -197,7 +197,7 @@ func TestLabelReflectorSimple(t *testing.T) {
 
 func TestLabelReflectorFull(t *testing.T) {
 	rlr := label.RecursiveReflector{}
-	fillLabels(reflect.TypeOf(typed.Stats{}), &rlr, "", types.LabelNames{})
+	fillLabels(reflect.TypeOf(typed.Stats{}), &rlr, "", types.LabelNames{}, func(value string) (labelName string) { return value })
 	d := cmp.Diff(rlr, expectedRecursive, cmp.Comparer(internal.CompareType))
 	if d != "" {
 		t.Fatal("Diff", d)

--- a/v0/pkg/prometheus/gen/testdata/simple_transformation_expected.txt
+++ b/v0/pkg/prometheus/gen/testdata/simple_transformation_expected.txt
@@ -1,0 +1,6 @@
+# HELP brokers_localhost_9092_2_rxbytes_total Total number of bytes received
+# TYPE brokers_localhost_9092_2_rxbytes_total counter
+brokers_localhost_9092_2_rxbytes_total{brokersname="localhost:9092/2",name="rdkafka#producer-1"} 15708
+# HELP rx_bytes_total Total number of bytes received from Kafka brokers
+# TYPE rx_bytes_total counter
+rx_bytes_total{name="rdkafka#producer-1"} 31084

--- a/v0/pkg/prometheus/types/transform.go
+++ b/v0/pkg/prometheus/types/transform.go
@@ -1,0 +1,3 @@
+package types
+
+type LabelNameTransformer func(value string) (labelName string)


### PR DESCRIPTION
Initial use case is to allow for Label name transformation.